### PR TITLE
Fix lint errors for fibRoute typing

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,8 +1,9 @@
 // Endpoint for querying the fibonacci numbers
 
 import fibonacci from "./fib";
+import { Request, Response } from "express";
 
-export default (req, res) => {
+export default (req: Request, res: Response) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
I have added types to the req and res in the function's parameter using Express's Request and Response. I also tested this code by running "npm run lint", which only showed errors in the code that were caused by the fib file. The changes made to the fibRoute.ts should fix the GitHub Actions lint & test errors.